### PR TITLE
Update default constructor for class GPTEngine

### DIFF
--- a/nl2ltl/engines/gpt/core.py
+++ b/nl2ltl/engines/gpt/core.py
@@ -57,7 +57,7 @@ class GPTEngine(Engine):
         self,
         model: str = Models.GPT4.value,
         prompt: Path = PROMPT_PATH,
-        operation_mode: str = OperationModes.COMPLETION.value,
+        operation_mode: str = OperationModes.CHAT.value,
         temperature: float = 0.5,
     ):
         """GPT LLM Engine initialization."""


### PR DESCRIPTION
When using the default parameters in the _GPTEngine_ class constructor error _"openai.error.InvalidRequestError"_ would happen due to the use of the COMPLETION mode with GPT4 engine.